### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -194,7 +194,7 @@ for more information.
 </p>
 <ol>
   <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
-  <li><a href="https://carpentries.org/files/assessment/TheCarpentries2018AnnualReport.pdf">The Carpentries 2018 Annual Report</a></li>
+  <li><a href="https://carpentries.org/files/reports/TheCarpentries2018AnnualReport.pdf">The Carpentries 2018 Annual Report</a></li>
 </ol>
 <p>
   Please also read through <em>one</em> episode of one of The Carpentries lessons below   

--- a/index.md
+++ b/index.md
@@ -194,7 +194,7 @@ for more information.
 </p>
 <ol>
   <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
-  <li><a href="https://carpentries.org/files/reports/TheCarpentries2018AnnualReport.pdf">The Carpentries 2018 Annual Report</a></li>
+  <li><a href="https://carpentries.org/files/reports/TheCarpentries2019AnnualReport.pdf">The Carpentries 2019 Annual Report</a></li>
 </ol>
 <p>
   Please also read through <em>one</em> episode of one of The Carpentries lessons below   


### PR DESCRIPTION
Hi,

Under the preparations section, the 2nd reading, "The Carpentries 2018 Annual Report" URL leads to an error. It may be fixed as follows:

Current 404 URL:
https://carpentries.org/files/assessment/TheCarpentries2018AnnualReport.pdf

Proposed new URL:
https://carpentries.org/files/reports/TheCarpentries2018AnnualReport.pdf